### PR TITLE
Update encoding and decoding to match the refactored algorithms from the paper

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -44,10 +44,10 @@ func main() {
 	fmt.Println()
 
 	// Decode
-	success, decrypted, error := purbs.Decode(blob, &recipients[0], publicFixedParams, verbose)
+	success, decrypted, err := purbs.Decode(blob, &recipients[0], publicFixedParams, verbose)
 
 	fmt.Println("Success:", success)
-	fmt.Println("Error message:", error)
+	fmt.Println("Error message:", err)
 	fmt.Println(string(decrypted))
 	fmt.Println(hex.Dump(decrypted))
 }
@@ -55,7 +55,7 @@ func main() {
 func getDummySuiteInfo() purbs.SuiteInfoMap {
 	info := make(purbs.SuiteInfoMap)
 	cornerstoneLength := 32 // defined by Curve 25519
-	entryPointLength := 16 + 4 // 16 bytes for key, 4 byte for pointer
+	entryPointLength := 16 + 4 + 16 // 16-byte symmetric key + 4-byte offset position + 16-byte authentication tag
 	info[curve25519.NewBlakeSHA256Curve25519(true).String()] = &purbs.SuiteInfo{
 		AllowedPositions: []int{12 + 0*cornerstoneLength, 12 + 1*cornerstoneLength, 12 + 3*cornerstoneLength, 12 + 4*cornerstoneLength},
 		CornerstoneLength: cornerstoneLength, EntryPointLength: entryPointLength}

--- a/purbs/decode.go
+++ b/purbs/decode.go
@@ -1,8 +1,6 @@
 package purbs
 
 import (
-	"crypto/aes"
-	"crypto/cipher"
 	"encoding/binary"
 	"errors"
 
@@ -186,22 +184,4 @@ func payloadTrialDecrypt(entrypoint []byte, fullPURBBlob []byte) (bool, string, 
 	}
 
 	return true, "", msg
-}
-
-// Decrypt using AEAD
-func aeadDecrypt(ciphertext, nonce, key, additional []byte) ([]byte, error) {
-
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, err
-	}
-	aesgcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, err
-	}
-
-	// Encrypt and authenticate payload
-	decrypted, err := aesgcm.Open(nil, nonce, ciphertext, additional)
-
-	return decrypted, err
 }

--- a/purbs/definitions.go
+++ b/purbs/definitions.go
@@ -16,7 +16,7 @@ const OFFSET_POINTER_LEN = 4
 const NONCE_LENGTH = 12
 
 // Length (in bytes) of the MAC tag in the entry point (only used with entrypoints are encrypted with AEAD)
-const MAC_AUTHENTICATION_TAG_LENGTH = SYMMETRIC_KEY_LENGTH
+const MAC_AUTHENTICATION_TAG_LENGTH = 32
 
 // Structure to define the whole PURB
 type Purb struct {

--- a/purbs/encode.go
+++ b/purbs/encode.go
@@ -408,11 +408,7 @@ func (purb *Purb) padThenEncryptData(data []byte, stream cipher.Stream) {
 	}
 
 	payloadKey := KDF("enc", purb.SessionKey)
-	payload, err := aeadEncrypt(paddedData, purb.Nonce, payloadKey, nil, stream)
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-	purb.Payload = payload
+	purb.Payload = streamEncrypt(paddedData, payloadKey)
 
 	if purb.IsVerbose {
 		log.LLvlf3("Payload padded encrypted to %v (len %v)", purb.Payload, len(purb.Payload))

--- a/purbs/encode.go
+++ b/purbs/encode.go
@@ -1,14 +1,14 @@
 package purbs
 
 import (
-	"crypto/aes"
 	"crypto/cipher"
 	"encoding/binary"
+	"sort"
+	"strconv"
+
 	"github.com/dedis/kyber/util/key"
 	"github.com/dedis/kyber/util/random"
 	"github.com/dedis/onet/log"
-	"sort"
-	"strconv"
 )
 
 // Creates a struct with parameters that are *fixed* across all PURBs. Should be constants, but here it is a variable for simulating various parameters
@@ -537,29 +537,6 @@ func (purb *Purb) placePayloadAndCornerstones() {
 	}
 
 	purb.byteRepresentation = buffer.toBytes()
-}
-
-// Encrypt using AEAD
-func aeadEncrypt(data, nonce, key, additional []byte, stream cipher.Stream) ([]byte, error) {
-
-	// If no key is passed, generate a random 16-byte key and create a cipher from it
-	if key == nil {
-		key := make([]byte, SYMMETRIC_KEY_LENGTH)
-		random.Bytes(key, stream)
-	}
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, err
-	}
-	aesgcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, err
-	}
-
-	// Encrypt and authenticate payload
-	encrypted := aesgcm.Seal(nil, nonce, data, additional)
-
-	return encrypted, nil
 }
 
 // ToBytes get the []byte representation of the PURB

--- a/purbs/purb_test.go
+++ b/purbs/purb_test.go
@@ -159,7 +159,7 @@ func TestEncodeDecodeSimplified(t *testing.T) {
 
 func getDummySuiteInfo(N int) SuiteInfoMap {
 
-	entryPointLen := 16 + 4
+	entryPointLen := 16 + 4 + 16
 	cornerstoneLen := 32
 	aeadNonceLen := 12
 

--- a/purbs/purb_test.go
+++ b/purbs/purb_test.go
@@ -17,7 +17,7 @@ func TestGenCornerstones(t *testing.T) {
 		Nonce:      nil,
 		Header:     nil,
 		Payload:    nil,
-		PayloadKey: nil,
+		SessionKey: nil,
 
 		IsVerbose:        true,
 		Recipients:       nil,

--- a/purbs/simulation.go
+++ b/purbs/simulation.go
@@ -48,15 +48,15 @@ func SimulMeasureEncodingTimePrecise(nRepeat int, recipients []int, suites []int
 					Nonce:            nil,
 					Header:           nil,
 					Payload:          nil,
-					PayloadKey:       nil,
+					SessionKey:       nil,
 					Recipients:       recipients,
 					Stream:           random.New(),
 					OriginalData:     msg, // just for statistics
 					PublicParameters: publicFixedParams,
 					IsVerbose:        simulationIsVerbose,
 				}
-				purb.Nonce = purb.randomBytes(AEAD_NONCE_LENGTH)
-				purb.PayloadKey = purb.randomBytes(SYMMETRIC_KEY_LENGTH)
+				purb.Nonce = purb.randomBytes(NONCE_LENGTH)
+				purb.SessionKey = purb.randomBytes(SYMMETRIC_KEY_LENGTH)
 
 				// creation of the entrypoints and cornerstones, places entrypoint and cornerstones
 				purb.Header = newEmptyHeader()
@@ -228,7 +228,7 @@ func SimulMeasureHeaderSize(nRepeat int, numRecipients []int) string {
 
 	si := createInfo()
 	key := make([]byte, SYMMETRIC_KEY_LENGTH)
-	nonce := make([]byte, AEAD_NONCE_LENGTH)
+	nonce := make([]byte, NONCE_LENGTH)
 	random.Bytes(key, random.New())
 	random.Bytes(nonce, random.New())
 
@@ -245,7 +245,7 @@ func SimulMeasureHeaderSize(nRepeat int, numRecipients []int) string {
 				Nonce:            nonce,
 				Header:           nil,
 				Payload:          nil,
-				PayloadKey:       key,
+				SessionKey:       key,
 				IsVerbose:        false,
 				Recipients:       decs,
 				Stream:           random.New(),
@@ -264,7 +264,7 @@ func SimulMeasureHeaderSize(nRepeat int, numRecipients []int) string {
 				Nonce:            nonce,
 				Header:           nil,
 				Payload:          nil,
-				PayloadKey:       key,
+				SessionKey:       key,
 				IsVerbose:        false,
 				Recipients:       decs,
 				Stream:           random.New(),
@@ -424,7 +424,7 @@ func SimulMeasureHeaderCompactness(nRepeat int, recipients []int, suites []int) 
 	resultsPURBs := new(Results)
 
 	key := make([]byte, SYMMETRIC_KEY_LENGTH)
-	nonce := make([]byte, AEAD_NONCE_LENGTH)
+	nonce := make([]byte, NONCE_LENGTH)
 	random.Bytes(key, random.New())
 	random.Bytes(nonce, random.New())
 
@@ -445,7 +445,7 @@ func SimulMeasureHeaderCompactness(nRepeat int, recipients []int, suites []int) 
 					Nonce:            nonce,
 					Header:           nil,
 					Payload:          nil,
-					PayloadKey:       key,
+					SessionKey:       key,
 					IsVerbose:        false,
 					Recipients:       decs,
 					Stream:           random.New(),
@@ -497,7 +497,7 @@ func shiftByAEAD_NONCE_LENGTH(pos []int) []int {
 	res := make([]int, len(pos))
 
 	for i := 0; i < len(pos); i++ {
-		res[i] = AEAD_NONCE_LENGTH + pos[i]
+		res[i] = NONCE_LENGTH + pos[i]
 	}
 
 	return res

--- a/purbs/simulation.go
+++ b/purbs/simulation.go
@@ -16,6 +16,9 @@ import (
 	"time"
 )
 
+// Fixed for the simulation: 16-byte symmetric key + 4-byte offset position + 16-byte authentication tag
+const ENTRYPOINT_LENGTH = 16 + 4 + 16
+
 const simulationIsVerbose = false
 const simulationUsesSimplifiedLayout = false
 
@@ -83,7 +86,7 @@ func SimulMeasureEncodingTimePrecise(nRepeat int, recipients []int, suites []int
 				resultsPayload.add(nRecipients, nSuites, k, -1, -1, nRepeat, m.recordAndReset())
 				// converts everything to []byte, performs the XOR trick on the cornerstones
 
-				purb.placePayloadAndCornerstones()
+				purb.placePayloadAndCornerstones(purb.Stream)
 
 				resultsCSAndEPValues.add(nRecipients, nSuites, k, -1, -1, nRepeat, m.recordAndReset())
 
@@ -471,7 +474,7 @@ func SimulMeasureHeaderCompactness(nRepeat int, recipients []int, suites []int) 
 
 func createInfo() SuiteInfoMap {
 
-	entryPointLen := 16 + 4
+	entryPointLen := ENTRYPOINT_LENGTH
 	cornerstoneLen := 32
 
 	info := make(SuiteInfoMap)
@@ -493,7 +496,7 @@ func createDecoders(n int) []Recipient {
 	return decs
 }
 
-func shiftByAEAD_NONCE_LENGTH(pos []int) []int {
+func shiftByNONCE_LENGTH(pos []int) []int {
 	res := make([]int, len(pos))
 
 	for i := 0; i < len(pos); i++ {
@@ -516,32 +519,32 @@ func createMultiInfoReal(N int) SuiteInfoMap {
 	info := make(SuiteInfoMap)
 
 	info["PURB_A"] = &SuiteInfo{
-		AllowedPositions:  shiftByAEAD_NONCE_LENGTH([]int{0}),
+		AllowedPositions:  shiftByNONCE_LENGTH([]int{0}),
 		CornerstoneLength: 64,
 		EntryPointLength:  48,
 	}
 	info["PURB_B"] = &SuiteInfo{
-		AllowedPositions:  shiftByAEAD_NONCE_LENGTH([]int{0, 64}),
+		AllowedPositions:  shiftByNONCE_LENGTH([]int{0, 64}),
 		CornerstoneLength: 32,
 		EntryPointLength:  48,
 	}
 	info["PURB_C"] = &SuiteInfo{
-		AllowedPositions:  shiftByAEAD_NONCE_LENGTH([]int{0, 64, 96}),
+		AllowedPositions:  shiftByNONCE_LENGTH([]int{0, 64, 96}),
 		CornerstoneLength: 64,
 		EntryPointLength:  80,
 	}
 	info["PURB_D"] = &SuiteInfo{
-		AllowedPositions:  shiftByAEAD_NONCE_LENGTH([]int{0, 32, 64, 160}),
+		AllowedPositions:  shiftByNONCE_LENGTH([]int{0, 32, 64, 160}),
 		CornerstoneLength: 32,
 		EntryPointLength:  80,
 	}
 	info["PURB_E"] = &SuiteInfo{
-		AllowedPositions:  shiftByAEAD_NONCE_LENGTH([]int{0, 64, 128, 192}),
+		AllowedPositions:  shiftByNONCE_LENGTH([]int{0, 64, 128, 192}),
 		CornerstoneLength: 64,
 		EntryPointLength:  64,
 	}
 	info["PURB_F"] = &SuiteInfo{
-		AllowedPositions:  shiftByAEAD_NONCE_LENGTH([]int{0, 32, 64, 96, 128, 256}),
+		AllowedPositions:  shiftByNONCE_LENGTH([]int{0, 32, 64, 96, 128, 256}),
 		CornerstoneLength: 32,
 		EntryPointLength:  64,
 	}
@@ -561,7 +564,7 @@ func createMultiInfoReal(N int) SuiteInfoMap {
 
 func createMultiInfo(N int) SuiteInfoMap {
 
-	entryPointLen := 16 + 4
+	entryPointLen := ENTRYPOINT_LENGTH
 	cornerstoneLen := 32
 	aeadNonceLen := 12
 

--- a/purbs/simulation.go
+++ b/purbs/simulation.go
@@ -88,6 +88,8 @@ func SimulMeasureEncodingTimePrecise(nRepeat int, recipients []int, suites []int
 
 				purb.placePayloadAndCornerstones(purb.Stream)
 
+				purb.addMAC()
+
 				resultsCSAndEPValues.add(nRecipients, nSuites, k, -1, -1, nRepeat, m.recordAndReset())
 
 				blob := purb.ToBytes()

--- a/purbs/utils.go
+++ b/purbs/utils.go
@@ -132,7 +132,7 @@ func aeadDecrypt(ciphertext, nonce, key, additional []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	// Encrypt and authenticate payload
+	// Decrypt and verify payload
 	decrypted, err := aesgcm.Open(nil, nonce, ciphertext, additional)
 
 	return decrypted, err

--- a/purbs/utils.go
+++ b/purbs/utils.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/dedis/kyber/group/curve25519"
 	"github.com/dedis/kyber/util/random"
 )
 
@@ -135,6 +136,26 @@ func aeadDecrypt(ciphertext, nonce, key, additional []byte) ([]byte, error) {
 	decrypted, err := aesgcm.Open(nil, nonce, ciphertext, additional)
 
 	return decrypted, err
+}
+
+// Encrypt using a stream cipher Blake2xb where key is used as the seed
+func streamEncrypt(data, key []byte) []byte {
+	ciphertext := make([]byte, len(data))
+	suite := curve25519.NewBlakeSHA256Curve25519(true)
+	xof := suite.XOF(key)
+	xof.XORKeyStream(ciphertext, data)
+
+	return ciphertext
+}
+
+// Encrypt using a stream cipher Blake2xb
+func streamDecrypt(ciphertext, key []byte) []byte {
+	data := make([]byte, len(ciphertext))
+	suite := curve25519.NewBlakeSHA256Curve25519(true)
+	xof := suite.XOF(key)
+	xof.XORKeyStream(data, ciphertext)
+
+	return data
 }
 
 // KDF derives a key from a purpose string and seed bytes

--- a/purbs/utils.go
+++ b/purbs/utils.go
@@ -3,7 +3,6 @@ package purbs
 import (
 	"crypto/sha256"
 	"fmt"
-	"golang.org/x/crypto/pbkdf2"
 	"strconv"
 	"strings"
 )
@@ -93,9 +92,13 @@ func (purb *Purb) VisualRepresentation(withBoundaries bool) string {
 	return "\n" + top + body + bottom
 }
 
-// KDF derives a key from shared bytes
-func KDF(password []byte) []byte {
-	return pbkdf2.Key(password, nil, 1, 32, sha256.New)
+// KDF derives a key from a purpose string and seed bytes
+func KDF(purpose string, seed []byte) []byte {
+	h := sha256.New()
+	h.Write([]byte(purpose))
+	h.Write(seed)
+	return h.Sum(nil)
+	//return pbkdf2.Key(password, nil, 1, 32, sha256.New)
 }
 
 func (si SuiteInfo) String() string {

--- a/purbs/utils_test.go
+++ b/purbs/utils_test.go
@@ -1,0 +1,18 @@
+package purbs
+
+import (
+	"github.com/dedis/onet/log"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestStreamCipher(t *testing.T) {
+	data := []byte("very secret information")
+	key := []byte("full of entropy")
+
+	ctxt := streamEncrypt(data, key)
+	log.Lvl2("Encrypted stream output: ", ctxt)
+	plxt := streamDecrypt(ctxt, key)
+
+	require.Equal(t, data, plxt)
+}


### PR DESCRIPTION
Change of key derivation, authenticated encryption for entry points (size of entry points is +16 bytes), non-authenticated symmetric encryption for payload, computing a MAC over a whole PURB.