### PR TITLE
Encrypt-then-pad instead of pad-then-encrypt

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -3,10 +3,10 @@ package main
 import (
 	"encoding/hex"
 	"fmt"
+	"github.com/dedis/purb/purbs"
 	"gopkg.in/dedis/kyber.v2/group/curve25519"
 	"gopkg.in/dedis/kyber.v2/util/key"
 	"gopkg.in/dedis/kyber.v2/util/random"
-	"github.com/dedis/purb/purbs"
 )
 
 func main() {
@@ -55,7 +55,7 @@ func main() {
 func getDummySuiteInfo() purbs.SuiteInfoMap {
 	info := make(purbs.SuiteInfoMap)
 	cornerstoneLength := 32 // defined by Curve 25519
-	entryPointLength := 16 + 4 + 16 // 16-byte symmetric key + 4-byte offset position + 16-byte authentication tag
+	entryPointLength := 16 + 4 + 4 + 16 // 16-byte symmetric key + 2 * 4-byte offset positions + 16-byte authentication tag
 	info[curve25519.NewBlakeSHA256Curve25519(true).String()] = &purbs.SuiteInfo{
 		AllowedPositions: []int{12 + 0*cornerstoneLength, 12 + 1*cornerstoneLength, 12 + 3*cornerstoneLength, 12 + 4*cornerstoneLength},
 		CornerstoneLength: cornerstoneLength, EntryPointLength: entryPointLength}

--- a/purbs/definitions.go
+++ b/purbs/definitions.go
@@ -11,7 +11,10 @@ import (
 const SYMMETRIC_KEY_LENGTH = 16
 
 // Length (in bytes) of the pointer to the start of the payload
-const OFFSET_POINTER_LEN = 4
+const START_OFFSET_LEN = 4
+
+// Length (in bytes) of the pointer to the end of the payload
+const END_OFFSET_LEN = START_OFFSET_LEN
 
 // Length (in bytes) of the Nonce used at the beginning of the PURB
 const NONCE_LENGTH = 12
@@ -25,15 +28,16 @@ type Purb struct {
 
 	Nonce      []byte // Nonce used in both AEAD of entrypoints and payload. The same for different entrypoints as the keys are different. It is stored in the very beginning of the purb
 	Header     *Header
-	Payload    []byte        // Payload contains already padded plaintext
+	Payload    []byte        // Payload contains already encrypted and padded plaintext
 	SessionKey []byte        // SessionKey is encapsulated and used to derive PayloadKey and MacKey
 	Recipients []Recipient   // tuple with (Suite, PublicKey, PrivateKey)
-	Stream     cipher.Stream // Used to get randomness
+	Stream     cipher.Stream // used to get randomness
 
 	byteRepresentation []byte // the end-to-end random-looking bit array returned by ToBytes() is computed at creation time
 
-	OriginalData []byte // Kept to compare between "Payload" and this
-	IsVerbose    bool   // If true, the various operations on the data structure will print what is happening
+	EncryptedDataLen int    // used to record the end of encrypted data in the entry points
+	OriginalData     []byte // kept to compare between "Payload" and this
+	IsVerbose        bool   // if true, the various operations on the data structure will print what is happening
 }
 
 // This struct's contents are *not* parameters to the PURBs. Here they vary for the simulations and the plots, but they should be fixed for all purbs

--- a/purbs/padding_test.go
+++ b/purbs/padding_test.go
@@ -6,20 +6,20 @@ import (
 )
 
 func TestPad(t *testing.T) {
-	msg := []byte("this is a long message that is supposed to be padded by 0x80 and 3 zero bytes") // 77 bytes
+	msg := []byte("this is a message that is supposed to be padded with 5 random bytes") // 67 bytes
 	result := pad(msg, 0)
-	require.Equal(t, 80, len(result))
+	require.Equal(t, 72, len(result))
 	// Now we add an overhead of 7 bytes representing the header
 	headerLen := 7
 	result = pad(msg, headerLen)
-	require.Equal(t, 88, len(result)+headerLen)
+	require.Equal(t, 80, len(result)+headerLen)
 }
 
 func TestUnPad(t *testing.T) {
+	var padLen int = 4
 	msg := []byte("I am an unpadded message")
-	msgPadded := append(msg, STARTPADBYTE)
-	msgPadded = append(msgPadded, make([]byte, 4)...)
-	result := unPad(msgPadded)
+	msgPadded := append(msg, make([]byte, padLen)...)
+	result := unPad(msgPadded, len(msg))
 	require.Equal(t, msg, result)
 }
 

--- a/purbs/purb_test.go
+++ b/purbs/purb_test.go
@@ -159,7 +159,7 @@ func TestEncodeDecodeSimplified(t *testing.T) {
 
 func getDummySuiteInfo(N int) SuiteInfoMap {
 
-	entryPointLen := 16 + 4 + 16
+	entryPointLen := 16 + 4 + 4 + 16
 	cornerstoneLen := 32
 	aeadNonceLen := 12
 

--- a/purbs/simulation.go
+++ b/purbs/simulation.go
@@ -5,19 +5,20 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"math/rand"
+	"os"
 	"syscall"
+	"time"
 
 	"github.com/dedis/purb/experiments-encoding/pgp"
 	"gopkg.in/dedis/kyber.v2/group/curve25519"
 	"gopkg.in/dedis/kyber.v2/util/key"
 	"gopkg.in/dedis/kyber.v2/util/random"
-	"math/rand"
-	"os"
-	"time"
 )
 
-// Fixed for the simulation: 16-byte symmetric key + 4-byte offset position + 16-byte authentication tag
-const ENTRYPOINT_LENGTH = 16 + 4 + 16
+// Fixed for the simulation: 16-byte symmetric key + 4-byte offset start position
+// + 4-byte offset end position + 16-byte authentication tag
+const ENTRYPOINT_LENGTH = 16 + 4 + 4 + 16
 
 const message_size = 1024 // 1 KB
 const simulationIsVerbose = false
@@ -82,7 +83,7 @@ func SimulMeasureEncodingTime(nRepeat int, recipients []int, suites []int) strin
 				resultsLayout.add(nRecipients, nSuites, k, -1, -1, nRepeat, m.recordAndReset())
 
 				// creation of the encrypted payload
-				purb.padThenEncryptData(msg, purb.Stream)
+				purb.encryptThenPadData(msg, purb.Stream)
 
 				resultsPayload.add(nRecipients, nSuites, k, -1, -1, nRepeat, m.recordAndReset())
 				// converts everything to []byte, performs the XOR trick on the cornerstones


### PR DESCRIPTION
Changes encrypt-then-pad to pad-then-encrypt, as defined by the paper. The padding is random bytes, instead of 0x80 followed by zero bytes.